### PR TITLE
Fix quick find dialog issues

### DIFF
--- a/src/main/java/org/quiltmc/syntaxpain/DocumentSearchData.java
+++ b/src/main/java/org/quiltmc/syntaxpain/DocumentSearchData.java
@@ -139,6 +139,24 @@ public class DocumentSearchData {
 			target.select(start, end);
 			return true;
 		} else {
+			if (this.isWrap()) {
+				// If there isn't a match before the cursor and wrapping is enabled, jump to the last one
+				while (matcher.find()) {
+					// Skip an already selected match
+					if (matcher.start() <= dot && matcher.end() >= dot) {
+						continue;
+					}
+
+					start = matcher.start();
+					end = matcher.end();
+				}
+
+				if (end > 0) {
+					target.select(start, end);
+					return true;
+				}
+			}
+
 			return false;
 		}
 	}

--- a/src/main/java/org/quiltmc/syntaxpain/QuickFindDialog.java
+++ b/src/main/java/org/quiltmc/syntaxpain/QuickFindDialog.java
@@ -230,8 +230,9 @@ public class QuickFindDialog extends JDialog implements DocumentListener, Action
 			var caretViewPos = target.modelToView2D(target.getCaretPosition());
 			int caretY = (int) caretViewPos.getY();
 
-			if (caretY >= target.getVisibleRect().height - this.getHeight()) {
-				target.scrollRectToVisible(new Rectangle((int) caretViewPos.getX(), caretY + this.getHeight() * 2, 1, 1));
+			if (caretY >= target.getVisibleRect().height - this.getHeight() * 2) {
+				int lineHeight = target.getFontMetrics(target.getFont()).getHeight();
+				target.scrollRectToVisible(new Rectangle((int) caretViewPos.getX(), caretY + lineHeight * 12, 1, 1));
 			}
 		} catch (BadLocationException ex) {
 			// ignore

--- a/src/main/java/org/quiltmc/syntaxpain/QuickFindDialog.java
+++ b/src/main/java/org/quiltmc/syntaxpain/QuickFindDialog.java
@@ -13,6 +13,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import javax.swing.text.BadLocationException;
 import javax.swing.text.JTextComponent;
 import java.awt.Color;
 import java.awt.Container;
@@ -20,6 +21,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Insets;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
@@ -95,7 +97,7 @@ public class QuickFindDialog extends JDialog implements DocumentListener, Action
 				target.requestFocus();
 			}
 		};
-		this.addWindowFocusListener(focusListener);
+		// this.addWindowFocusListener(focusListener);
 
 		this.target = new WeakReference<>(target);
 
@@ -199,18 +201,40 @@ public class QuickFindDialog extends JDialog implements DocumentListener, Action
 	}
 
 	private void prevButtonActionPerformed(ActionEvent e) {
-		if (this.searchData.get().doFindPrev(this.target.get())) {
+		JTextComponent target = this.target.get();
+		int caretPos = target.getCaretPosition();
+		if (this.searchData.get().doFindPrev(target)) {
 			this.statusLabel.setText(null);
+			this.prevCaretPos = caretPos;
+			this.fixOverlappedCaret();
 		} else {
 			this.statusLabel.setText("QuickFindDialog.NotFound");
 		}
 	}
 
 	private void nextButtonActionPerformed(ActionEvent e) {
-		if (this.searchData.get().doFindNext(this.target.get())) {
+		JTextComponent target = this.target.get();
+		int caretPos = target.getCaretPosition();
+		if (this.searchData.get().doFindNext(target)) {
 			this.statusLabel.setText(null);
+			this.prevCaretPos = caretPos;
+			this.fixOverlappedCaret();
 		} else {
 			this.statusLabel.setText("QuickFindDialog.NotFound");
+		}
+	}
+
+	private void fixOverlappedCaret() {
+		JTextComponent target = this.target.get();
+		try {
+			var caretViewPos = target.modelToView2D(target.getCaretPosition());
+			int caretY = (int) caretViewPos.getY();
+
+			if (caretY >= target.getVisibleRect().height - this.getHeight()) {
+				target.scrollRectToVisible(new Rectangle((int) caretViewPos.getX(), caretY + this.getHeight() * 2, 1, 1));
+			}
+		} catch (BadLocationException ex) {
+			// ignore
 		}
 	}
 

--- a/src/main/java/org/quiltmc/syntaxpain/QuickFindDialog.java
+++ b/src/main/java/org/quiltmc/syntaxpain/QuickFindDialog.java
@@ -97,7 +97,7 @@ public class QuickFindDialog extends JDialog implements DocumentListener, Action
 				target.requestFocus();
 			}
 		};
-		// this.addWindowFocusListener(focusListener);
+		this.addWindowFocusListener(focusListener);
 
 		this.target = new WeakReference<>(target);
 


### PR DESCRIPTION
Fixes the search bar overlapping the matched text, and the "previous" button not wrapping around with the wrap option enabled. Fixes #1 