### PR TITLE
call `fixOverlappedCaret` in `updateFind`

### DIFF
--- a/src/main/java/org/quiltmc/syntaxpain/QuickFindDialog.java
+++ b/src/main/java/org/quiltmc/syntaxpain/QuickFindDialog.java
@@ -291,6 +291,7 @@ public class QuickFindDialog extends JDialog implements DocumentListener, Action
 				this.statusLabel.setText(this.notFound);
 			} else {
 				this.statusLabel.setText(null);
+				this.fixOverlappedCaret();
 			}
 		} catch (PatternSyntaxException e) {
 			this.statusLabel.setText(e.getDescription());


### PR DESCRIPTION
#3 only affected next/prev buttons; this applies the same scroll adjustment when the search term updates
to test I just published to maven local and tried searching in enigma