### PR TITLE
Quick find tool bar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,10 @@ repositories {
     mavenCentral()
 }
 
+final ENV = System.getenv()
+
 group = 'org.quiltmc'
-version = '0.1.5'
+version = "0.1.5${ENV.GITHUB_ACTIONS ? '' : '+local'}"
 
 // exclude auto-generated jflex lexer from checkstyle
 tasks.withType(Checkstyle).configureEach {
@@ -31,7 +33,6 @@ publishing {
     repositories {
         mavenLocal()
 
-        def ENV = System.getenv()
         if (ENV.MAVEN_URL) {
             maven {
                 url ENV.MAVEN_URL

--- a/src/main/java/org/quiltmc/syntaxpain/DocumentSearchData.java
+++ b/src/main/java/org/quiltmc/syntaxpain/DocumentSearchData.java
@@ -14,6 +14,7 @@
 
 package org.quiltmc.syntaxpain;
 
+import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -84,21 +85,20 @@ public class DocumentSearchData {
 	}
 
 	/**
-	 * Gets the Search data from a Document.  If document does not have any
-	 * search data, then a new instance is added, put and reurned.
-	 * @param target JTextCOmponent we are attaching to
+	 * Gets the search data from a document. If the document does not have any
+	 * search data, then a new instance is added and returned.
+	 *
+	 * @param document the document to retrieve data from
+	 *
+	 * @return the document's search data
 	 */
-	public static DocumentSearchData getFromEditor(JTextComponent target) {
-		if (target == null) {
-			return null;
-		}
-
-		Object o = target.getDocument().getProperty(PROPERTY_KEY);
-		if (o instanceof DocumentSearchData documentSearchData) {
+	public static DocumentSearchData getFrom(Document document) {
+		Object value = document.getProperty(PROPERTY_KEY);
+		if (value instanceof DocumentSearchData documentSearchData) {
 			return documentSearchData;
 		} else {
 			DocumentSearchData newDSD = new DocumentSearchData();
-			target.getDocument().putProperty(PROPERTY_KEY, newDSD);
+			document.putProperty(PROPERTY_KEY, newDSD);
 			return newDSD;
 		}
 	}

--- a/src/main/java/org/quiltmc/syntaxpain/JavaSyntaxKit.java
+++ b/src/main/java/org/quiltmc/syntaxpain/JavaSyntaxKit.java
@@ -84,7 +84,11 @@ public class JavaSyntaxKit extends DefaultEditorKit implements ViewFactory {
 
 		Color caretColor = SyntaxpainConfiguration.getTextColor();
 		editorPane.setCaretColor(caretColor);
-		this.addQuickFindAction(editorPane);
+
+		if (SyntaxpainConfiguration.isQuickFindDialogEnabled()) {
+			this.addQuickFindDialogAction(editorPane);
+		}
+
 		this.addComponents(editorPane);
 	}
 
@@ -103,13 +107,13 @@ public class JavaSyntaxKit extends DefaultEditorKit implements ViewFactory {
 	/**
 	 * Sets up the quick find action.
 	 */
-	public void addQuickFindAction(JEditorPane editorPane) {
+	public void addQuickFindDialogAction(JEditorPane editorPane) {
 		InputMap inputMap = new InputMap();
 		inputMap.setParent(editorPane.getInputMap());
 		ActionMap actionMap = new ActionMap();
 		actionMap.setParent(editorPane.getActionMap());
 
-		QuickFindAction action = new QuickFindAction();
+		QuickFindDialogAction action = new QuickFindDialogAction();
 		actionMap.put(action.getClass().getSimpleName(), action);
 
 		KeyStroke stroke = KeyStroke.getKeyStroke("control F");

--- a/src/main/java/org/quiltmc/syntaxpain/QuickFindDialog.java
+++ b/src/main/java/org/quiltmc/syntaxpain/QuickFindDialog.java
@@ -39,7 +39,8 @@ public class QuickFindDialog extends JDialog implements EscapeListener {
 		layout.setVerticalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
 				.addComponent(this.quickFindToolBar, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE));
 
-		this.setName("QuickFindDialog");
+		final String simpleName = this.getClass().getSimpleName();
+		this.setName(simpleName.isEmpty() ? QuickFindDialog.class.getSimpleName() : simpleName);
 
 		Util.addEscapeListener(this);
 	}

--- a/src/main/java/org/quiltmc/syntaxpain/QuickFindDialog.java
+++ b/src/main/java/org/quiltmc/syntaxpain/QuickFindDialog.java
@@ -23,8 +23,6 @@ public class QuickFindDialog extends JDialog implements EscapeListener {
 
 	protected QuickFindToolBar quickFindToolBar;
 
-	protected String componentName = "QuickFindDialog";
-
 	public QuickFindDialog(JTextComponent target) {
 		super(SwingUtilities.getWindowAncestor(target), ModalityType.MODELESS);
 
@@ -41,7 +39,7 @@ public class QuickFindDialog extends JDialog implements EscapeListener {
 		layout.setVerticalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
 				.addComponent(this.quickFindToolBar, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE));
 
-		this.translate();
+		this.setName("QuickFindDialog");
 
 		Util.addEscapeListener(this);
 	}
@@ -72,12 +70,6 @@ public class QuickFindDialog extends JDialog implements EscapeListener {
 		this.quickFindToolBar.showFor(target);
 
 		this.setVisible(true);
-	}
-
-	protected void translate() {
-		this.quickFindToolBar.translate();
-		this.setName(this.componentName);
-		this.pack();
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/syntaxpain/QuickFindDialog.java
+++ b/src/main/java/org/quiltmc/syntaxpain/QuickFindDialog.java
@@ -1,83 +1,52 @@
 package org.quiltmc.syntaxpain;
 
-import javax.swing.BorderFactory;
 import javax.swing.GroupLayout;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
 import javax.swing.JDialog;
-import javax.swing.JLabel;
-import javax.swing.JTextField;
-import javax.swing.JToolBar;
-import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
-import javax.swing.text.BadLocationException;
 import javax.swing.text.JTextComponent;
 import java.awt.Color;
 import java.awt.Container;
 import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.Insets;
 import java.awt.Point;
-import java.awt.Rectangle;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.awt.event.WindowFocusListener;
-import java.lang.ref.WeakReference;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
+import java.util.function.Function;
 
 /**
- * A dialog used to find instances of specific strings in a {@link JTextComponent}.
- * Designed to be extensible.
+ * A dialog containing a {@link QuickFindToolBar}.
+ *
+ * @see SyntaxpainConfiguration#setQuickFindDialogFactory(Function)
  */
-public class QuickFindDialog extends JDialog implements DocumentListener, ActionListener, EscapeListener {
-	protected static final int SEARCH_FIELD_MAX_WIDTH = 200;
-	protected static final int SEARCH_FIELD_MAX_HEIGHT = 24;
-	protected static final int SEARCH_FIELD_MIN_WIDTH = 60;
-	private static final int SEARCH_FIELD_MIN_HEIGHT = 24;
+public class QuickFindDialog extends JDialog implements EscapeListener {
 	protected static final int PREFERRED_TOOLBAR_WIDTH = 684;
 
-	protected final Markers.SimpleMarker marker = new Markers.SimpleMarker(Color.PINK);
-	protected WeakReference<JTextComponent> target;
-	protected final WeakReference<DocumentSearchData> searchData;
-	protected int prevCaretPos;
+	protected QuickFindToolBar quickFindToolBar;
 
-	protected JLabel statusLabel;
-	protected JTextField searchField;
-	protected JButton prevButton;
-	protected JButton nextButton;
-	protected JCheckBox ignoreCaseCheckBox;
-	protected JCheckBox regexCheckBox;
-	protected JCheckBox wrapCheckBox;
-
-	protected String prev = "prev";
-	protected String next = "next";
 	protected String componentName = "QuickFindDialog";
-	protected String ignoreCase = "Ignore case";
-	protected String useRegex = "Use regex";
-	protected String wrap = "Wrap";
-	protected String notFound = "Not found";
 
 	public QuickFindDialog(JTextComponent target) {
-		this(target, DocumentSearchData.getFromEditor(target));
-	}
-
-	public QuickFindDialog(JTextComponent target, DocumentSearchData searchData) {
 		super(SwingUtilities.getWindowAncestor(target), ModalityType.MODELESS);
 
-		this.initComponents();
+		this.quickFindToolBar = new QuickFindToolBar();
+		this.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+		this.setBackground(Color.DARK_GRAY);
+		this.setResizable(false);
+		this.setUndecorated(true);
+
+		GroupLayout layout = new GroupLayout(this.getContentPane());
+		this.getContentPane().setLayout(layout);
+		layout.setHorizontalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+				.addComponent(this.quickFindToolBar, GroupLayout.DEFAULT_SIZE, PREFERRED_TOOLBAR_WIDTH, Short.MAX_VALUE));
+		layout.setVerticalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
+				.addComponent(this.quickFindToolBar, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE));
+
+		this.translate();
+
 		Util.addEscapeListener(this);
-		this.searchData = new WeakReference<>(searchData);
 	}
 
 	public void showFor(JTextComponent target) {
-		this.prevCaretPos = target.getCaretPosition();
-
 		Container view = target.getParent();
 		Dimension size = this.getSize();
 
@@ -91,217 +60,24 @@ public class QuickFindDialog extends JDialog implements DocumentListener, Action
 		SwingUtilities.convertPointToScreen(loc, view);
 		this.setLocation(loc);
 
-		this.searchField.setFont(target.getFont());
-		this.searchField.getDocument().addDocumentListener(this);
-
 		// Close the dialog when clicking outside it
-		WindowFocusListener focusListener = new WindowAdapter() {
+		this.addWindowFocusListener(new WindowAdapter() {
 			@Override
 			public void windowLostFocus(WindowEvent e) {
-				target.getDocument().removeDocumentListener(QuickFindDialog.this);
-				Markers.removeMarkers(target, QuickFindDialog.this.marker);
 				QuickFindDialog.this.removeWindowListener(this);
 				QuickFindDialog.this.setVisible(false);
-				target.requestFocus();
 			}
-		};
-		this.addWindowFocusListener(focusListener);
+		});
 
-		this.target = new WeakReference<>(target);
-
-		DocumentSearchData searchData = this.searchData.get();
-		this.wrapCheckBox.setSelected(searchData.isWrap());
-
-		// Set the search field to the current selection
-		String selectedText = target.getSelectedText();
-		if (selectedText != null) {
-			this.searchField.setText(selectedText);
-		} else {
-			Pattern pattern = searchData.getPattern();
-			if (pattern != null) {
-				this.searchField.setText(pattern.pattern());
-			}
-		}
-
-		this.searchField.selectAll();
+		this.quickFindToolBar.showFor(target);
 
 		this.setVisible(true);
 	}
 
-	protected void initComponents() {
-		JToolBar toolBar = new JToolBar();
-		this.statusLabel = new JLabel();
-		this.searchField = new JTextField();
-		this.prevButton = new JButton(this.prev);
-		this.nextButton = new JButton(this.next);
-		this.ignoreCaseCheckBox = new JCheckBox(this.ignoreCase);
-		this.regexCheckBox = new JCheckBox(this.useRegex);
-		this.wrapCheckBox = new JCheckBox(this.wrap);
-
-		this.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
-		this.setBackground(Color.DARK_GRAY);
-		this.setResizable(false);
-		this.setUndecorated(true);
-
-		toolBar.setBorder(BorderFactory.createEtchedBorder());
-		toolBar.setFloatable(false);
-		toolBar.setRollover(true);
-		toolBar.addSeparator();
-
-		this.searchField.setColumns(30);
-		this.searchField.setBorder(BorderFactory.createLineBorder(Color.BLACK));
-		this.searchField.setMaximumSize(new Dimension(SEARCH_FIELD_MAX_WIDTH, SEARCH_FIELD_MAX_HEIGHT));
-		this.searchField.setMinimumSize(new Dimension(SEARCH_FIELD_MIN_WIDTH, SEARCH_FIELD_MIN_HEIGHT));
-		toolBar.add(this.searchField);
-		toolBar.addSeparator();
-
-		this.prevButton.setHorizontalTextPosition(SwingConstants.CENTER);
-		this.prevButton.setFocusable(false);
-		this.prevButton.setOpaque(false);
-		this.prevButton.setVerticalTextPosition(SwingConstants.BOTTOM);
-		this.prevButton.addActionListener(this::prevButtonActionPerformed);
-		toolBar.add(this.prevButton);
-
-		this.nextButton.setHorizontalTextPosition(SwingConstants.CENTER);
-		this.nextButton.setMargin(new Insets(2, 2, 2, 2));
-		this.nextButton.setFocusable(false);
-		this.nextButton.setOpaque(false);
-		this.nextButton.setVerticalTextPosition(SwingConstants.BOTTOM);
-		this.nextButton.addActionListener(this::nextButtonActionPerformed);
-		toolBar.add(this.nextButton);
-
-		toolBar.addSeparator();
-
-		this.ignoreCaseCheckBox.setFocusable(false);
-		this.ignoreCaseCheckBox.setOpaque(false);
-		this.ignoreCaseCheckBox.setVerticalTextPosition(SwingConstants.BOTTOM);
-		this.ignoreCaseCheckBox.addActionListener(this);
-		toolBar.add(this.ignoreCaseCheckBox);
-
-		this.regexCheckBox.setFocusable(false);
-		this.regexCheckBox.setOpaque(false);
-		this.regexCheckBox.setVerticalTextPosition(SwingConstants.BOTTOM);
-		this.regexCheckBox.addActionListener(this);
-		toolBar.add(this.regexCheckBox);
-
-		this.wrapCheckBox.setFocusable(false);
-		this.wrapCheckBox.setOpaque(false);
-		this.wrapCheckBox.setVerticalTextPosition(SwingConstants.BOTTOM);
-		this.wrapCheckBox.addActionListener(this);
-		toolBar.add(this.wrapCheckBox);
-
-		this.statusLabel.setFont(this.statusLabel.getFont().deriveFont(this.statusLabel.getFont().getStyle() | Font.BOLD));
-		this.statusLabel.setForeground(Color.RED);
-		toolBar.addSeparator();
-		toolBar.add(this.statusLabel);
-
-		GroupLayout layout = new GroupLayout(this.getContentPane());
-		this.getContentPane().setLayout(layout);
-		layout.setHorizontalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
-				.addComponent(toolBar, GroupLayout.DEFAULT_SIZE, PREFERRED_TOOLBAR_WIDTH, Short.MAX_VALUE));
-		layout.setVerticalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
-				.addComponent(toolBar, GroupLayout.PREFERRED_SIZE, GroupLayout.DEFAULT_SIZE, GroupLayout.PREFERRED_SIZE));
-
-		this.translate();
-	}
-
 	protected void translate() {
-		this.nextButton.setText(this.next);
-		this.prevButton.setText(this.prev);
+		this.quickFindToolBar.translate();
 		this.setName(this.componentName);
-		this.ignoreCaseCheckBox.setText(this.ignoreCase);
-		this.regexCheckBox.setText(this.useRegex);
-		this.wrapCheckBox.setText(this.wrap);
 		this.pack();
-	}
-
-	private void prevButtonActionPerformed(ActionEvent e) {
-		JTextComponent target = this.target.get();
-		int caretPos = target.getCaretPosition();
-		if (this.searchData.get().doFindPrev(target)) {
-			this.statusLabel.setText(null);
-			this.prevCaretPos = caretPos;
-			this.fixOverlappedCaret();
-		} else {
-			this.statusLabel.setText(this.notFound);
-		}
-	}
-
-	private void nextButtonActionPerformed(ActionEvent e) {
-		JTextComponent target = this.target.get();
-		int caretPos = target.getCaretPosition();
-		if (this.searchData.get().doFindNext(target)) {
-			this.statusLabel.setText(null);
-			this.prevCaretPos = caretPos;
-			this.fixOverlappedCaret();
-		} else {
-			this.statusLabel.setText(this.notFound);
-		}
-	}
-
-	private void fixOverlappedCaret() {
-		JTextComponent target = this.target.get();
-		try {
-			var caretViewPos = target.modelToView2D(target.getCaretPosition());
-			int caretY = (int) caretViewPos.getY();
-
-			if (caretY >= target.getVisibleRect().height - this.getHeight() * 2) {
-				int lineHeight = target.getFontMetrics(target.getFont()).getHeight();
-				target.scrollRectToVisible(new Rectangle((int) caretViewPos.getX(), caretY + lineHeight * 12, 1, 1));
-			}
-		} catch (BadLocationException ex) {
-			// ignore
-		}
-	}
-
-	@Override
-	public void insertUpdate(DocumentEvent e) {
-		this.updateFind();
-	}
-
-	@Override
-	public void removeUpdate(DocumentEvent e) {
-		this.updateFind();
-	}
-
-	@Override
-	public void changedUpdate(DocumentEvent e) {
-		this.updateFind();
-	}
-
-	private void updateFind() {
-		JTextComponent target = this.target.get();
-		DocumentSearchData searchData = this.searchData.get();
-		String searchText = this.searchField.getText();
-
-		if (searchText == null || searchText.isEmpty() || target == null || searchData == null) {
-			this.statusLabel.setText(null);
-			return;
-		}
-
-		try {
-			searchData.setWrap(this.wrapCheckBox.isSelected());
-			searchData.setPattern(searchText, this.regexCheckBox.isSelected(), this.ignoreCaseCheckBox.isSelected());
-			this.statusLabel.setText(null);
-
-			// The DocumentSearchData doFindNext will always find from current pos,
-			// so we need to relocate to our saved pos before we call doFindNext
-			target.setCaretPosition(this.prevCaretPos);
-			if (!searchData.doFindNext(target)) {
-				this.statusLabel.setText(this.notFound);
-			} else {
-				this.statusLabel.setText(null);
-			}
-		} catch (PatternSyntaxException e) {
-			this.statusLabel.setText(e.getDescription());
-		}
-	}
-
-	@Override
-	public void actionPerformed(ActionEvent e) {
-		if (e.getSource() instanceof JCheckBox) {
-			this.updateFind();
-		}
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/syntaxpain/QuickFindDialogAction.java
+++ b/src/main/java/org/quiltmc/syntaxpain/QuickFindDialogAction.java
@@ -3,9 +3,9 @@ package org.quiltmc.syntaxpain;
 import javax.swing.text.JTextComponent;
 import java.awt.event.ActionEvent;
 
-public final class QuickFindAction extends DefaultSyntaxAction {
-	public QuickFindAction() {
-		super("quick-find");
+public final class QuickFindDialogAction extends DefaultSyntaxAction {
+	public QuickFindDialogAction() {
+		super("quick-find-dialog");
 	}
 
 	@Override
@@ -33,11 +33,13 @@ public final class QuickFindAction extends DefaultSyntaxAction {
 		}
 
 		public void showFindDialog(JTextComponent target) {
-			if (this.findDialog == null) {
-				this.findDialog = SyntaxpainConfiguration.getQuickFindDialog(target);
-			}
+			if (SyntaxpainConfiguration.isQuickFindDialogEnabled()) {
+				if (this.findDialog == null) {
+					this.findDialog = SyntaxpainConfiguration.getQuickFindDialog(target);
+				}
 
-			this.findDialog.showFor(target);
+				this.findDialog.showFor(target);
+			}
 		}
 	}
 }

--- a/src/main/java/org/quiltmc/syntaxpain/QuickFindToolBar.java
+++ b/src/main/java/org/quiltmc/syntaxpain/QuickFindToolBar.java
@@ -307,6 +307,7 @@ public class QuickFindToolBar extends JToolBar implements DocumentListener, Acti
 			target.setCaretPosition(this.prevCaretPos);
 			if (searchData.doFindNext(target)) {
 				this.statusLabel.setText(null);
+				this.fixOverlappedCaret();
 			} else {
 				this.statusLabel.setText(this.notFound);
 			}

--- a/src/main/java/org/quiltmc/syntaxpain/QuickFindToolBar.java
+++ b/src/main/java/org/quiltmc/syntaxpain/QuickFindToolBar.java
@@ -1,0 +1,324 @@
+package org.quiltmc.syntaxpain;
+
+import javax.swing.AbstractAction;
+import javax.swing.ActionMap;
+import javax.swing.BorderFactory;
+import javax.swing.InputMap;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JTextField;
+import javax.swing.JToolBar;
+import javax.swing.KeyStroke;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.JTextComponent;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.KeyEvent;
+import java.lang.ref.WeakReference;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * A toolbar used to find instances of specific strings in a {@link JTextComponent}.
+ * Designed to be extensible.
+ *
+ * @see QuickFindDialog
+ */
+public class QuickFindToolBar extends JToolBar implements DocumentListener, ActionListener {
+	protected static final int SEARCH_FIELD_MAX_WIDTH = 200;
+	protected static final int SEARCH_FIELD_MAX_HEIGHT = 24;
+	protected static final int SEARCH_FIELD_MIN_WIDTH = 60;
+	private static final int SEARCH_FIELD_MIN_HEIGHT = 24;
+
+	protected final Markers.SimpleMarker marker = new Markers.SimpleMarker(Color.PINK);
+	protected WeakReference<JTextComponent> target = new WeakReference<>(null);
+	protected WeakReference<DocumentSearchData> searchData = new WeakReference<>(null);
+	protected int prevCaretPos;
+
+	protected JLabel statusLabel;
+	protected JTextField searchField;
+	protected JButton prevButton;
+	protected JButton nextButton;
+	protected JCheckBox ignoreCaseCheckBox;
+	protected JCheckBox regexCheckBox;
+	protected JCheckBox wrapCheckBox;
+
+	protected String prev = "prev";
+	protected String next = "next";
+	protected String ignoreCase = "Ignore case";
+	protected String useRegex = "Use regex";
+	protected String wrap = "Wrap";
+	protected String notFound = "Not found";
+
+	public QuickFindToolBar() {
+		this.initComponents();
+	}
+
+	public void showFor(JTextComponent target) {
+		this.searchData = new WeakReference<>(DocumentSearchData.getFrom(target.getDocument()));
+		this.target = new WeakReference<>(target);
+
+		this.prevCaretPos = target.getCaretPosition();
+
+		Container view = target.getParent();
+		Dimension size = this.getSize();
+
+		// Set the width of the dialog to the width of the target
+		size.width = target.getVisibleRect().width;
+		this.setSize(size);
+
+		// Put the dialog at the bottom of the target
+		Point loc = new Point(0, view.getHeight() - size.height);
+		SwingUtilities.convertPointToScreen(loc, view);
+		this.setLocation(loc);
+
+		this.searchField.setFont(target.getFont());
+
+		DocumentSearchData searchData = this.searchData.get();
+		this.wrapCheckBox.setSelected(searchData.isWrap());
+
+		// Set the search field to the current selection
+		String selectedText = target.getSelectedText();
+		if (selectedText != null) {
+			this.searchField.setText(selectedText);
+		} else {
+			Pattern pattern = searchData.getPattern();
+			if (pattern != null) {
+				this.searchField.setText(pattern.pattern());
+			}
+		}
+
+		this.setVisible(true);
+		this.searchField.requestFocus();
+		this.searchField.selectAll();
+	}
+
+	protected void initComponents() {
+		this.statusLabel = new JLabel();
+		this.searchField = new JTextField();
+		this.prevButton = new JButton(this.prev);
+		this.nextButton = new JButton(this.next);
+		this.ignoreCaseCheckBox = new JCheckBox(this.ignoreCase);
+		this.regexCheckBox = new JCheckBox(this.useRegex);
+		this.wrapCheckBox = new JCheckBox(this.wrap);
+
+		this.setBorder(BorderFactory.createEtchedBorder());
+		this.setFloatable(false);
+		this.setRollover(true);
+		this.addSeparator();
+
+		this.searchField.setColumns(30);
+		this.searchField.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+		this.searchField.setMaximumSize(new Dimension(SEARCH_FIELD_MAX_WIDTH, SEARCH_FIELD_MAX_HEIGHT));
+		this.searchField.setMinimumSize(new Dimension(SEARCH_FIELD_MIN_WIDTH, SEARCH_FIELD_MIN_HEIGHT));
+		this.add(this.searchField);
+		this.addSeparator();
+
+		this.prevButton.setHorizontalTextPosition(SwingConstants.CENTER);
+		this.prevButton.setFocusable(false);
+		this.prevButton.setOpaque(false);
+		this.prevButton.setVerticalTextPosition(SwingConstants.BOTTOM);
+		this.prevButton.addActionListener(this::prevButtonActionPerformed);
+		this.add(this.prevButton);
+
+		this.nextButton.setHorizontalTextPosition(SwingConstants.CENTER);
+		this.nextButton.setMargin(new Insets(2, 2, 2, 2));
+		this.nextButton.setFocusable(false);
+		this.nextButton.setOpaque(false);
+		this.nextButton.setVerticalTextPosition(SwingConstants.BOTTOM);
+		this.nextButton.addActionListener(this::nextButtonActionPerformed);
+		this.add(this.nextButton);
+
+		this.addSeparator();
+
+		this.ignoreCaseCheckBox.setFocusable(false);
+		this.ignoreCaseCheckBox.setOpaque(false);
+		this.ignoreCaseCheckBox.setVerticalTextPosition(SwingConstants.BOTTOM);
+		this.ignoreCaseCheckBox.addActionListener(this);
+		this.add(this.ignoreCaseCheckBox);
+
+		this.regexCheckBox.setFocusable(false);
+		this.regexCheckBox.setOpaque(false);
+		this.regexCheckBox.setVerticalTextPosition(SwingConstants.BOTTOM);
+		this.regexCheckBox.addActionListener(this);
+		this.add(this.regexCheckBox);
+
+		this.wrapCheckBox.setFocusable(false);
+		this.wrapCheckBox.setOpaque(false);
+		this.wrapCheckBox.setVerticalTextPosition(SwingConstants.BOTTOM);
+		this.wrapCheckBox.addActionListener(this);
+		this.add(this.wrapCheckBox);
+
+		this.statusLabel.setFont(this.statusLabel.getFont().deriveFont(this.statusLabel.getFont().getStyle() | Font.BOLD));
+		this.statusLabel.setForeground(Color.RED);
+		this.addSeparator();
+		this.add(this.statusLabel);
+
+		final InputMap inputMap = this.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
+		if (inputMap != null) {
+			final ActionMap actionMap = this.getActionMap();
+			if (actionMap != null) {
+				final KeyStroke escape = KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0, false);
+				final String actionMapKey = "close-quick-find";
+				inputMap.put(escape, actionMapKey);
+				actionMap.put(actionMapKey, new AbstractAction() {
+					@Override
+					public void actionPerformed(ActionEvent e) {
+						QuickFindToolBar.this.setVisible(false);
+					}
+				});
+			}
+		}
+
+		this.searchField.getDocument().addDocumentListener(this);
+
+		// global listener instead of FocusListener so it receives events for children
+		Toolkit.getDefaultToolkit().addAWTEventListener(
+				e -> {
+					if (e instanceof FocusEvent focus) {
+						final Component component = focus.getComponent();
+						final boolean componentDescends = component != null
+								&& SwingUtilities.isDescendingFrom(component, QuickFindToolBar.this);
+						final Component opposite = focus.getOppositeComponent();
+						final boolean oppositeDescends = opposite != null
+								&& SwingUtilities.isDescendingFrom(opposite, QuickFindToolBar.this);
+
+						if (componentDescends != oppositeDescends) {
+							final boolean descendantGained = focus.getID() == FocusEvent.FOCUS_GAINED
+									? componentDescends
+									: oppositeDescends;
+
+							if (descendantGained) {
+								// document.addDocumentListener(QuickFindToolBar.this);
+								QuickFindToolBar.this.setVisible(true);
+							} else {
+								// document.removeDocumentListener(QuickFindToolBar.this);
+								QuickFindToolBar.this.setVisible(false);
+								final JTextComponent target = QuickFindToolBar.this.target.get();
+								if (target != null) {
+									Markers.removeMarkers(target, QuickFindToolBar.this.marker);
+									target.requestFocus();
+								}
+							}
+						}
+					}
+				},
+				FocusEvent.FOCUS_LOST | FocusEvent.FOCUS_GAINED
+		);
+
+		this.translate();
+	}
+
+	protected void translate() {
+		this.nextButton.setText(this.next);
+		this.prevButton.setText(this.prev);
+		this.ignoreCaseCheckBox.setText(this.ignoreCase);
+		this.regexCheckBox.setText(this.useRegex);
+		this.wrapCheckBox.setText(this.wrap);
+	}
+
+	private void prevButtonActionPerformed(ActionEvent e) {
+		JTextComponent target = this.target.get();
+		int caretPos = target.getCaretPosition();
+		if (this.searchData.get().doFindPrev(target)) {
+			this.statusLabel.setText(null);
+			this.prevCaretPos = caretPos;
+			this.fixOverlappedCaret();
+		} else {
+			this.statusLabel.setText(this.notFound);
+		}
+	}
+
+	private void nextButtonActionPerformed(ActionEvent e) {
+		JTextComponent target = this.target.get();
+		int caretPos = target.getCaretPosition();
+		if (this.searchData.get().doFindNext(target)) {
+			this.statusLabel.setText(null);
+			this.prevCaretPos = caretPos;
+			this.fixOverlappedCaret();
+		} else {
+			this.statusLabel.setText(this.notFound);
+		}
+	}
+
+	private void fixOverlappedCaret() {
+		JTextComponent target = this.target.get();
+		try {
+			var caretViewPos = target.modelToView2D(target.getCaretPosition());
+			int caretY = (int) caretViewPos.getY();
+
+			if (caretY >= target.getVisibleRect().height - this.getHeight() * 2) {
+				int lineHeight = target.getFontMetrics(target.getFont()).getHeight();
+				target.scrollRectToVisible(new Rectangle((int) caretViewPos.getX(), caretY + lineHeight * 12, 1, 1));
+			}
+		} catch (BadLocationException ex) {
+			// ignore
+		}
+	}
+
+	@Override
+	public void insertUpdate(DocumentEvent e) {
+		this.updateFind();
+	}
+
+	@Override
+	public void removeUpdate(DocumentEvent e) {
+		this.updateFind();
+	}
+
+	@Override
+	public void changedUpdate(DocumentEvent e) {
+		this.updateFind();
+	}
+
+	private void updateFind() {
+		JTextComponent target = this.target.get();
+		DocumentSearchData searchData = this.searchData.get();
+		String searchText = this.searchField.getText();
+
+		if (searchText == null || searchText.isEmpty() || target == null || searchData == null) {
+			this.statusLabel.setText(null);
+			return;
+		}
+
+		try {
+			searchData.setWrap(this.wrapCheckBox.isSelected());
+			searchData.setPattern(searchText, this.regexCheckBox.isSelected(), this.ignoreCaseCheckBox.isSelected());
+			this.statusLabel.setText(null);
+
+			// The DocumentSearchData doFindNext will always find from current pos,
+			// so we need to relocate to our saved pos before we call doFindNext
+			target.setCaretPosition(this.prevCaretPos);
+			if (searchData.doFindNext(target)) {
+				this.statusLabel.setText(null);
+			} else {
+				this.statusLabel.setText(this.notFound);
+			}
+		} catch (PatternSyntaxException e) {
+			this.statusLabel.setText(e.getDescription());
+		}
+	}
+
+	@Override
+	public void actionPerformed(ActionEvent e) {
+		if (e.getSource() instanceof JCheckBox) {
+			this.updateFind();
+		}
+	}
+}

--- a/src/main/java/org/quiltmc/syntaxpain/SyntaxpainConfiguration.java
+++ b/src/main/java/org/quiltmc/syntaxpain/SyntaxpainConfiguration.java
@@ -1,5 +1,6 @@
 package org.quiltmc.syntaxpain;
 
+import javax.swing.JEditorPane;
 import javax.swing.text.JTextComponent;
 import java.awt.Color;
 import java.awt.Font;
@@ -138,21 +139,26 @@ public class SyntaxpainConfiguration {
 		JavaSyntaxKit.setFont(font);
 	}
 
+	/**
+	 * @return whether automatic installation of {@link QuickFindDialog}s in {@link JEditorPane}s is enabled
+	 */
 	public static boolean isQuickFindDialogEnabled() {
 		return quickFindDialogFactory != null;
 	}
 
 	/**
-	 * @return a new dialog, or {@code null} if {@link #quickFindDialogFactory} is {@code null}
+	 * @return a new dialog, or {@code null} if {@linkplain  #isQuickFindDialogEnabled dialogs are disabled}
 	 */
 	public static QuickFindDialog getQuickFindDialog(JTextComponent component) {
 		return quickFindDialogFactory == null ? null : quickFindDialogFactory.apply(component);
 	}
 
 	/**
-	 * Set's the factory method used by {@link #getQuickFindDialog(JTextComponent)}  to create new dialogs.
+	 * Set's the factory method used by {@link #getQuickFindDialog(JTextComponent)} to create new dialogs.
 	 *
-	 * @param dialogFactory the dialog factory; may be {@code null}
+	 * <p> Pass {@code null} to disable automatic installation of {@link QuickFindDialog}s in {@link JEditorPane}s.
+	 *
+	 * @param dialogFactory the dialog factory; may be {@code null}, but a factory must not return {@code null}
 	 */
 	public static void setQuickFindDialogFactory(Function<JTextComponent, QuickFindDialog> dialogFactory) {
 		quickFindDialogFactory = dialogFactory;

--- a/src/main/java/org/quiltmc/syntaxpain/SyntaxpainConfiguration.java
+++ b/src/main/java/org/quiltmc/syntaxpain/SyntaxpainConfiguration.java
@@ -138,10 +138,22 @@ public class SyntaxpainConfiguration {
 		JavaSyntaxKit.setFont(font);
 	}
 
-	public static QuickFindDialog getQuickFindDialog(JTextComponent component) {
-		return quickFindDialogFactory.apply(component);
+	public static boolean isQuickFindDialogEnabled() {
+		return quickFindDialogFactory != null;
 	}
 
+	/**
+	 * @return a new dialog, or {@code null} if {@link #quickFindDialogFactory} is {@code null}
+	 */
+	public static QuickFindDialog getQuickFindDialog(JTextComponent component) {
+		return quickFindDialogFactory == null ? null : quickFindDialogFactory.apply(component);
+	}
+
+	/**
+	 * Set's the factory method used by {@link #getQuickFindDialog(JTextComponent)}  to create new dialogs.
+	 *
+	 * @param dialogFactory the dialog factory; may be {@code null}
+	 */
 	public static void setQuickFindDialogFactory(Function<JTextComponent, QuickFindDialog> dialogFactory) {
 		quickFindDialogFactory = dialogFactory;
 	}


### PR DESCRIPTION
- extracts `QuickFindToolBar` from `QuickFindDialog`
- disables automatic `QuickFindDialog` creation when `SyntaxpainConfiguration` has `null` dialog factory
- eliminates `initComponents()` because it could lead to unexpected behavior due to it being called from the constructor
- eliminates `translate()` as translation was not supported and subclasses can implement their own translation 

Supersede #4.
Facilitates https://github.com/QuiltMC/enigma/pull/304 superseding #5

Can be manually tested by publishing locally, then on https://github.com/QuiltMC/enigma/pull/304 running `:enigma-swing:completeTestGui`.